### PR TITLE
Implemented nrf24_write function

### DIFF
--- a/src/nrf24_mod.c
+++ b/src/nrf24_mod.c
@@ -565,7 +565,7 @@ static ssize_t nrf24_write(struct file *filp, const char __user *buf, size_t cou
             goto exit;
         }
 
-        if(mutex_lock_interruptible(&(nrf24_dev->tx_fifo_lock)){
+        if(mutex_lock_interruptible(&(nrf24_dev->tx_fifo_lock))){
             dev_err(&(nrf24_dev->dev), "%s: failed to lock tx fifo mutex\n", __func__);
             goto exit;
         }
@@ -575,7 +575,7 @@ static ssize_t nrf24_write(struct file *filp, const char __user *buf, size_t cou
             goto exit_unlock_mutex;
         }
 
-        mutex_unlock(&(nrf24_dev->tx_fifo_lock);
+        mutex_unlock(&(nrf24_dev->tx_fifo_lock));
 
         if(filp->f_flags & O_NONBLOCK){
             copied += tx_data.size;


### PR DESCRIPTION
Implement the nrf24_write function in the nrf24_mod.c file. This function handles writing data to the nrf24 device file. It copies data from the user and writes it to the transmit (tx) FIFO. Non-blocking mode is supported.
Ref #3 